### PR TITLE
Optimize category aggregation during rendering

### DIFF
--- a/assets/app.js
+++ b/assets/app.js
@@ -124,6 +124,11 @@ function renderAll(){
     .filter(t => monthKey(t.date) === curYM)
     .sort((a,b) => a.date.localeCompare(b.date));
 
+  const catTotals = new Map();
+  txs.forEach(t => {
+    catTotals.set(t.categoryKey, (catTotals.get(t.categoryKey) ?? 0) + t.amountYen);
+  });
+
   const used = txs.reduce((s,t)=>s+t.amountYen,0);
   const cap = state.monthlyCapYen;
   const remain = cap - used;
@@ -143,7 +148,7 @@ function renderAll(){
   tbody.innerHTML = "";
   BUDGETS.forEach(b => {
     const budgetYen = b.monthlyMan * 10000;
-    const catUsed = txs.filter(t => t.categoryKey === b.key).reduce((s,t)=>s+t.amountYen,0);
+    const catUsed = catTotals.get(b.key) ?? 0;
     const catRemain = budgetYen - catUsed;
 
     const tr = document.createElement("tr");
@@ -159,8 +164,9 @@ function renderAll(){
   // tx list
   const txBody = $("tableTx").querySelector("tbody");
   txBody.innerHTML = "";
+  const catNameMap = new Map(BUDGETS.map(b => [b.key, b.name]));
   txs.forEach(t => {
-    const catName = BUDGETS.find(b=>b.key===t.categoryKey)?.name ?? t.categoryKey;
+    const catName = catNameMap.get(t.categoryKey) ?? t.categoryKey;
     const tr = document.createElement("tr");
     tr.innerHTML = `
       <td>${t.date}</td>


### PR DESCRIPTION
### Motivation
- Reduce repeated scans of the transaction list during UI rendering to improve performance for larger datasets.
- Precompute category aggregates and a name lookup to avoid expensive per-category and per-transaction searches.
- Keep rendering logic functionally identical while making it more efficient.

### Description
- Precompute a `Map` of category totals as `catTotals` to replace repeated `filter(...).reduce(...)` usage in `renderAll` in `assets/app.js`.
- Create a `catNameMap` `Map` from `BUDGETS` to replace `find` lookups when rendering transactions.
- Replace per-budget and per-transaction lookups with `catTotals.get(...) ?? 0` and `catNameMap.get(...) ?? key` respectively.
- No UI or data model changes beyond swapping repeated traversals for map lookups.

### Testing
- No automated tests were run for this change.
- Manual smoke: the app was re-rendered during development to verify behavior (no failures observed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695f588f41a4832da8c7e8f453dfd6c9)