### PR TITLE
Make budget configuration editable in-page

### DIFF
--- a/assets/styles.css
+++ b/assets/styles.css
@@ -34,12 +34,17 @@ button.danger{ background:#fff; color:#b91c1c; border-color:#fecaca;}
 table{ width:100%; border-collapse:collapse; font-size:14px; }
 th, td{ border-bottom:1px solid var(--bd); padding:10px 8px; text-align:left; vertical-align:top;}
 th{ color:var(--muted); font-weight:700; font-size:12px; }
-.table-edit input{
-  padding:6px 8px;
-  font-size:13px;
-  border-radius:8px;
-}
 .table-edit td{ vertical-align:middle; }
+.budget-form{
+  display:grid;
+  grid-template-columns: 1fr 1fr 1fr auto;
+  gap:10px;
+  align-items:end;
+}
+@media (max-width:900px){
+  .budget-form{ grid-template-columns:1fr; }
+  .budget-form .btns{ justify-content:flex-start; }
+}
 .pill{ display:inline-block; padding:4px 8px; border:1px solid var(--bd); border-radius:999px; font-size:12px; background:#fff;}
 .kpi{ display:flex; gap:12px; flex-wrap:wrap;}
 .kpi .box{ flex:1; min-width:180px; border:1px solid var(--bd); border-radius:12px; padding:10px; background:#fff;}

--- a/assets/styles.css
+++ b/assets/styles.css
@@ -34,6 +34,12 @@ button.danger{ background:#fff; color:#b91c1c; border-color:#fecaca;}
 table{ width:100%; border-collapse:collapse; font-size:14px; }
 th, td{ border-bottom:1px solid var(--bd); padding:10px 8px; text-align:left; vertical-align:top;}
 th{ color:var(--muted); font-weight:700; font-size:12px; }
+.table-edit input{
+  padding:6px 8px;
+  font-size:13px;
+  border-radius:8px;
+}
+.table-edit td{ vertical-align:middle; }
 .pill{ display:inline-block; padding:4px 8px; border:1px solid var(--bd); border-radius:999px; font-size:12px; background:#fff;}
 .kpi{ display:flex; gap:12px; flex-wrap:wrap;}
 .kpi .box{ flex:1; min-width:180px; border:1px solid var(--bd); border-radius:12px; padding:10px; background:#fff;}

--- a/index.html
+++ b/index.html
@@ -89,9 +89,28 @@
               <div class="small">预算配置（万日元/月）</div>
               <div class="muted">可修改类别名称与金额，删除不会影响已记录的数据。</div>
             </div>
-            <button id="btnAddBudget">新增类别</button>
           </div>
-          <table id="tableBudgetEdit" class="table-edit" style="margin-top:8px;">
+
+          <div class="budget-form" style="margin-top:10px;">
+            <div>
+              <label>类别代码</label>
+              <input id="budgetKey" placeholder="例如：US_TECH" />
+            </div>
+            <div>
+              <label>类别名称</label>
+              <input id="budgetName" placeholder="例如：美股科技" />
+            </div>
+            <div>
+              <label>预算（万日元/月）</label>
+              <input id="budgetMonthly" type="number" min="0" step="0.1" placeholder="例如：3.5" />
+            </div>
+            <div class="btns">
+              <button id="btnSaveBudget" class="primary">保存类别</button>
+              <button id="btnCancelBudget">清空</button>
+            </div>
+          </div>
+
+          <table id="tableBudgetEdit" class="table-edit" style="margin-top:12px;">
             <thead>
               <tr>
                 <th>类别代码</th>

--- a/index.html
+++ b/index.html
@@ -78,7 +78,30 @@
         </div>
 
         <div class="muted" style="margin-top:10px;">
-          预算配置在 <code>assets/budgets.js</code> 里；想改为网页可编辑我也能再帮你升级。
+          预算配置支持直接在网页里编辑，修改会自动保存到浏览器。
+        </div>
+
+        <hr class="hr" />
+
+        <div>
+          <div class="topline">
+            <div>
+              <div class="small">预算配置（万日元/月）</div>
+              <div class="muted">可修改类别名称与金额，删除不会影响已记录的数据。</div>
+            </div>
+            <button id="btnAddBudget">新增类别</button>
+          </div>
+          <table id="tableBudgetEdit" class="table-edit" style="margin-top:8px;">
+            <thead>
+              <tr>
+                <th>类别代码</th>
+                <th>类别名称</th>
+                <th class="right">预算（万日元/月）</th>
+                <th style="width:90px;"></th>
+              </tr>
+            </thead>
+            <tbody></tbody>
+          </table>
         </div>
       </div>
 


### PR DESCRIPTION
### Motivation
- The budget list was hard-coded in `assets/budgets.js` and needed to be editable from the web UI. 
- Users should be able to add, rename, remove and adjust per-category monthly budgets without editing source files. 
- Editable budgets must persist in browser storage and participate in import/export so configurations can be backed up and restored.

### Description
- Persist budget configuration in application state as `state.budgets`, add `normalizeBudgets` and `uniqueBudgetKey`, and replace usages of `BUDGETS` with `state.budgets` in reporting and category lookup. 
- Add a budget editor UI and controls (`btnAddBudget`, `tableBudgetEdit`) in `index.html` and implement editor rendering and interactions in `assets/app.js` to support add/update/remove and automatic saving. 
- Wire import/export to include budgets so imported JSON can restore the editable configuration, and update category select rendering via `renderCategoryOptions`. 
- Add minor styling for the budget editor table inputs in `assets/styles.css` for better alignment and readability.

### Testing
- Started a local HTTP server with `python -m http.server` and loaded the app to verify the page serves correctly. 
- Ran a Playwright smoke run that captured `artifacts/budget-editor.png` to confirm the budget editor UI renders; the screenshot run succeeded. 
- No unit tests were added or run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695f769227ec832da162a46668831c36)